### PR TITLE
fix: preserve blank lines after cell metadata in notebook serialization

### DIFF
--- a/src/vscode/notebook/spark/FabricSparkNotebookSerializer.ts
+++ b/src/vscode/notebook/spark/FabricSparkNotebookSerializer.ts
@@ -153,7 +153,7 @@ export class FabricSparkNotebookSerializer implements vscode.NotebookSerializer 
 				cellContent = cell.value;
 			}
 
-			output += `${commentChars} ${cellType} ${this.CELL_SEPARATOR_ASTERIXES}\n\n${cellContent}\n`;	
+			output += `${commentChars} ${cellType} ${this.CELL_SEPARATOR_ASTERIXES}\n\n${cellContent}\n\n`;	
 		}
 
 		return Buffer.from(output);


### PR DESCRIPTION
### What does this PR do?
Fixes the bug where saving a notebook locally collapses empty lines and breaks formatting in `notebook-content.py`. 

### How was it fixed?
Added a trailing newline sequence to the cell metadata serialization logic. This ensures a clean `\n\n` separation between the `# META }` closing bracket and the next `# CELL` header. 

Fixes #77